### PR TITLE
Fix AttributeError in create_custom.py

### DIFF
--- a/modules/create_custom.py
+++ b/modules/create_custom.py
@@ -19,7 +19,8 @@ def custom_pipeline():
     answers = inquirer.prompt(execution_env_question)
     executor_env = answers['executor_env']
 
-    scheduler_name = None  # Save name of scheduler if hpc selected
+    scheduler_name = None # Save name of scheduler if hpc selected
+    module_results = None # Save name of module if found 
 
     if executor_env == "hpc":
         scheduler_name = check_scheduler()

--- a/modules/create_hpc_env.py
+++ b/modules/create_hpc_env.py
@@ -67,7 +67,8 @@ def check_modules():
 
         else:
             print(Fore.YELLOW + "No modules system detected.")
-            return False
+            return {"not_detected": True}
+            
     except Exception as e:
         print(Fore.RED + "Error checking for modules system: " + str(e))
         return False


### PR DESCRIPTION
While running the configBuilder, encountered an AttributeError when the tool attempted to access the `get()` method on the `module_results` variable. Error trace indicated that `module_results` was treated as a boolean instead of a dictionary. Executed with:
```
python3 configBuilder
```

When no module detected, throws: 

```
Traceback (most recent call last):
  File "/home/james/git/jfy133/configBuilder-nf/configBuilder", line 39, in <module>
    custom_pipeline()
  File "/home/james/git/jfy133/configBuilder-nf/modules/create_custom.py", line 48, in custom_pipeline
    write_config(executor=scheduler_name, module_results=module_results)
  File "/home/james/git/jfy133/configBuilder-nf/modules/write_config.py", line 20, in write_config
    if module_results.get("singularity"):
       ^^^^^^^^^^^^^^^^^^
AttributeError: 'bool' object has no attribute 'get'
```

To fix, I've initialised `module_results=None` variable in the `custom_pipeline()` function in `create_custom.py` to prevent the AttributeError. 

@jfy133 could you test this resolves your issue? 
