### PR TITLE
Remove cloud option from infrastructure options

### DIFF
--- a/modules/create_infrastructure.py
+++ b/modules/create_infrastructure.py
@@ -14,14 +14,14 @@ def create_infrastructure():
         inquirer.List(
             "executor_env",
             message="What type of execution environment are you working in?",
-            choices=["hpc", "local", "cloud"],
+            choices=["hpc", "local"],
         ),
     ]
     answers = inquirer.prompt(execution_env_question)
     executor_env = answers["executor_env"]
 
-    scheduler_name = None # Save name of scheduler if hpc selected
-    module_results = None # Save name of module if found 
+    scheduler_name = None  # Save name of scheduler if hpc selected
+    module_results = None  # Save name of module if found
 
     # Printing the selected environment
     print(f"You selected: {executor_env}")


### PR DESCRIPTION
For now I suggest we remove this because:

1. It's harder to test the config once it's generated
2. There are actually very few options you would have to set, normally use AWS region and queue
3. It's likely going to get low usage (many people use tower to execute on AWS, so does configuration for you)

We can revisit it again in the future.