### PR TITLE
Fix writing of config to ensure no 'nonsense' output

### DIFF
--- a/modules/write_config.py
+++ b/modules/write_config.py
@@ -25,12 +25,17 @@ def write_config(executor, module_results=None):
 
     with open(output_file, "w") as f:
         f.write("// Custom Nextflow config file \n\n")
+
+        ## container options
         if module_results.get("singularity"):
             f.write("singularity {\n")
             f.write("    enabled = true\n")
             # f.write(f"    NXF_SINGULARITY_CACHEDIR = {singularity_cache} \n")
-        f.write("}\n\n")
+            f.write("}\n\n")
 
-        f.write("process {\n")
-        f.write(f"    executor = '{executor}'\n")
-        f.write("}\n\n")
+        ## Executor options
+        if executor is not "none":
+            f.write("process {\n")
+            if executor is not "none":
+                f.write(f"    executor = '{executor}'\n")
+            f.write("}\n\n")


### PR DESCRIPTION
Due to the earlier fix of skipping the selection of executor, we opted to use a 'none' indicator. However the writing function still executed but setting 'executor' to `none`, which makes no sense.

This PR deactivates writing of the executor option, and also the entire process scope, if executor is set to `none` (and in the future other process related parameters).

I do wonder if we should refactor how all the information is saved and then written to file. I wonder if it would be easier to save a (nested) dictionary like format, and then just write what is in there, rather than (as I've done here) just evaluate if each scope is not `none` (or false etc.) 

To make the writing easier, we could also use the 'long form' of writing configs, e.g. instead of 

```
process {
    executor = 'slurm'
}
```

we could write

```
process.executor = 'slurm'
```

