### PR TITLE
Autodetect which queues are available for detected scheduler

### DIFF
--- a/modules/create_hpc_env.py
+++ b/modules/create_hpc_env.py
@@ -81,7 +81,6 @@ def check_queues(detected_scheduler):
         pass
 
     elif detected_scheduler == "slurm":
-        # TODO confirm this actually works 
         cmd = "sinfo -h --format=%P,%c,%m,%l"
         result = subprocess.run(
             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE

--- a/modules/create_hpc_env.py
+++ b/modules/create_hpc_env.py
@@ -71,13 +71,13 @@ def check_queues(detected_scheduler):
         detected_queues = [line.split()[0] for line in output.split('\n')[2:] if line.strip()]
 
     elif detected_scheduler == "sge":
-        # TODO fix results,  
+        # TODO confirm this actually works  
         cmd = "qconf -sql"
         result = subprocess.run(
             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
-        output = result.stdout.decode("utf-8").strip() # untested
-        detected_queues = output.split('\n') # TODO untested, will need change
+        )
+        output = result.stdout.decode("utf-8").strip()
+        detected_queues = output.split('\n')
         pass
 
     elif detected_scheduler == "slurm":
@@ -85,9 +85,9 @@ def check_queues(detected_scheduler):
         cmd = "sinfo --format=%P,%c,%m,%l"
         result = subprocess.run(
             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
-        output = result.stdout.decode("utf-8").strip() # untested
-        detected_queues = output.split('\n') # TODO untested, will need to change
+        )
+        output = result.stdout.decode("utf-8").strip()
+        detected_queues = [line.split(',')[0] for line in output.split('\n') if line.strip()] 
         pass
 
     if detected_queues:

--- a/modules/create_hpc_env.py
+++ b/modules/create_hpc_env.py
@@ -82,7 +82,7 @@ def check_queues(detected_scheduler):
 
     elif detected_scheduler == "slurm":
         # TODO confirm this actually works 
-        cmd = "sinfo --format=%P,%c,%m,%l"
+        cmd = "sinfo -h --format=%P,%c,%m,%l"
         result = subprocess.run(
             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )

--- a/modules/create_hpc_env.py
+++ b/modules/create_hpc_env.py
@@ -71,7 +71,6 @@ def check_queues(detected_scheduler):
         detected_queues = [line.split()[0] for line in output.split('\n')[2:] if line.strip()]
 
     elif detected_scheduler == "sge":
-        # TODO confirm this actually works  
         cmd = "qconf -sql"
         result = subprocess.run(
             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE

--- a/modules/create_hpc_env.py
+++ b/modules/create_hpc_env.py
@@ -52,6 +52,16 @@ def check_scheduler():
 
     return detected_scheduler
 
+def check_queues(detected_scheduler):
+    """
+    Detect available job queues for auto-detected scheduler (SGE, PBSpro, SLURM). 
+    """
+    detected_queues = "none" 
+
+    if detected_scheduler != "none":
+        print(Fore.YELLOW + "Checking for available queues...\n")
+    
+    return detected_queues
 
 def check_modules():
     """

--- a/modules/create_hpc_env.py
+++ b/modules/create_hpc_env.py
@@ -52,41 +52,65 @@ def check_scheduler():
 
     return detected_scheduler
 
+import inquirer
+
 def check_queues(detected_scheduler):
     """
     Detect available job queues for auto-detected scheduler (SGE, PBSpro, SLURM). 
     """
-    detected_queues = "none" 
+    detected_queues = []
+
     print(Fore.YELLOW + "Checking for available queues...\n")
     
     if detected_scheduler == "pbspro":
         cmd = "qstat -Q"
         result = subprocess.run(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
         output = result.stdout.decode("utf-8").strip()
         detected_queues = [line.split()[0] for line in output.split('\n')[2:] if line.strip()]
 
-        if detected_queues:
-            print(Fore.GREEN + "Found queues...")
+    elif detected_scheduler == "sge":
+        # TODO fix results,  
+        cmd = "qconf -sql"
+        result = subprocess.run(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+        output = result.stdout.decode("utf-8").strip() # untested
+        detected_queues = output.split('\n') # TODO untested, will need change
+        pass
 
-            # Prompt user to select a queue
-            queue_question = [
-                inquirer.List(
-                    "selected_queue",
-                    message="Which queue do you want to execute your processes?",
-                    choices=detected_queues
-                )
-            ]
-            answers = inquirer.prompt(queue_question)
-            selected_queue = answers["selected_queue"]
+    elif detected_scheduler == "slurm":
+        # TODO confirm this actually works 
+        cmd = "sinfo --format=%P,%c,%m,%l"
+        result = subprocess.run(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+        output = result.stdout.decode("utf-8").strip() # untested
+        detected_queues = output.split('\n') # TODO untested, will need to change
+        pass
 
-            print("Selected queue:", selected_queue)
-            return selected_queue
-        else:
-            print(Fore.YELLOW + "No queues found.")
-        #print(Fore.GREEN + "Queues: {detected_queues} detected.\n")
+    if detected_queues:
+        print(Fore.GREEN + "Found queues!")
+
+        # Prompt user to select a queue
+        queue_question = [
+            inquirer.List(
+                "selected_queue",
+                message="Which job queue would you like to execute processes?",
+                choices=detected_queues
+            )
+        ]
+        answers = inquirer.prompt(queue_question)
+        selected_queue = answers["selected_queue"]
+
+        print("Selected queue:", selected_queue)
+        return selected_queue
+    else:
+        print(Fore.YELLOW + "No queues found.")
+
     return detected_queues
+
 
 def check_modules():
     """

--- a/modules/create_hpc_env.py
+++ b/modules/create_hpc_env.py
@@ -57,10 +57,35 @@ def check_queues(detected_scheduler):
     Detect available job queues for auto-detected scheduler (SGE, PBSpro, SLURM). 
     """
     detected_queues = "none" 
-
-    if detected_scheduler != "none":
-        print(Fore.YELLOW + "Checking for available queues...\n")
+    print(Fore.YELLOW + "Checking for available queues...\n")
     
+    if detected_scheduler == "pbspro":
+        cmd = "qstat -Q"
+        result = subprocess.run(
+                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+        output = result.stdout.decode("utf-8").strip()
+        detected_queues = [line.split()[0] for line in output.split('\n')[2:] if line.strip()]
+
+        if detected_queues:
+            print(Fore.GREEN + "Found queues...")
+
+            # Prompt user to select a queue
+            queue_question = [
+                inquirer.List(
+                    "selected_queue",
+                    message="Which queue do you want to execute your processes?",
+                    choices=detected_queues
+                )
+            ]
+            answers = inquirer.prompt(queue_question)
+            selected_queue = answers["selected_queue"]
+
+            print("Selected queue:", selected_queue)
+            return selected_queue
+        else:
+            print(Fore.YELLOW + "No queues found.")
+        #print(Fore.GREEN + "Queues: {detected_queues} detected.\n")
     return detected_queues
 
 def check_modules():

--- a/modules/create_infrastructure.py
+++ b/modules/create_infrastructure.py
@@ -50,7 +50,7 @@ def create_infrastructure():
     # Infra-type specific options (in future could add cloud e.g. for AWS specific scopes)
     if executor_env == "hpc":
         scheduler_name = check_scheduler()
-        if scheduler_name == "pbspro":
+        if scheduler_name != "none":
             print(f"The detected job scheduler is: {scheduler_name}.\n")
             queues_list = check_queues(scheduler_name)  # Pass the result of check_scheduler
         module_results = check_modules()

--- a/modules/create_infrastructure.py
+++ b/modules/create_infrastructure.py
@@ -6,7 +6,11 @@ from .create_params import (
     retrieve_computational_resources,
     question_max_resources,
 )
-from .create_hpc_env import check_scheduler, check_modules
+from .create_hpc_env import (
+    check_scheduler, 
+    check_queues,
+    check_modules,
+)
 from .write_config import write_config
 from colorama import Fore, Style, init
 import inquirer
@@ -37,6 +41,7 @@ def create_infrastructure():
     executor_env = answers["executor_env"]
 
     scheduler_name = None  # Save name of scheduler if hpc selected
+    queues_list = None # Save list of queues if job scheduler detected 
     module_results = None  # Save name of module if found
 
     # Printing the selected environment
@@ -45,9 +50,11 @@ def create_infrastructure():
     # Infra-type specific options (in future could add cloud e.g. for AWS specific scopes)
     if executor_env == "hpc":
         scheduler_name = check_scheduler()
-        module_results = check_modules()
-        if scheduler_name != "none":
+        if scheduler_name == "pbspro":
             print(f"The detected job scheduler is: {scheduler_name}.\n")
+            queues_list = check_queues(scheduler_name)  # Pass the result of check_scheduler
+        module_results = check_modules()
+
     else:
         pass
 

--- a/modules/create_infrastructure.py
+++ b/modules/create_infrastructure.py
@@ -41,7 +41,7 @@ def create_infrastructure():
     executor_env = answers["executor_env"]
 
     scheduler_name = None  # Save name of scheduler if hpc selected
-    queues_list = None # Save list of queues if job scheduler detected 
+    queue_name = None # Save list of queues if job scheduler detected 
     module_results = None  # Save name of module if found
 
     # Printing the selected environment
@@ -52,7 +52,7 @@ def create_infrastructure():
         scheduler_name = check_scheduler()
         if scheduler_name != "none":
             print(f"The detected job scheduler is: {scheduler_name}.\n")
-            queues_list = check_queues(scheduler_name)  # Pass the result of check_scheduler
+            queue_name = check_queues(scheduler_name)  # Pass the result of check_scheduler
         module_results = check_modules()
 
     else:
@@ -88,6 +88,7 @@ def create_infrastructure():
     write_config(
         cleanup_input,
         executor=scheduler_name,
+        queue=queue_name,
         module_results=module_results,
         container=container_results,
         params=nfcore_params,

--- a/modules/write_config.py
+++ b/modules/write_config.py
@@ -8,7 +8,7 @@ import os
 init(autoreset=True)
 
 
-def write_config(cleanup_input, executor, container, params=None, module_results=None):
+def write_config(cleanup_input, executor, queue, container, params=None, module_results=None):
     """
     Write the user's specifications to variables inside the config template below and output to a text file.
     """
@@ -36,6 +36,7 @@ def write_config(cleanup_input, executor, container, params=None, module_results
         if executor != "none":
             f.write("process {\n")
             f.write(f"    executor = '{executor}'\n")
+            f.write(f"    queue = '{queue}'\n")
             f.write("}\n\n")
 
         if container is not False:


### PR DESCRIPTION
Automatically detect which queues are available on the HPC system once a job scheduler (pbspro, slurm, sge) is detected. 

Closes https://github.com/georgiesamaha/configBuilder-nf/issues/7